### PR TITLE
Sort blog entries by date (descending)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/get-blog-feed.yml
+++ b/.github/workflows/get-blog-feed.yml
@@ -18,3 +18,4 @@ jobs:
           labels: |
             'actions'
             'copilot'
+          days: 7

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A GitHub Action that lists [GitHub Blog](https://github.blog/) entries that matc
 - `token` - A token with `repo` scope
 - `dry-run` - If `true`, the RSS feed will only be reported in the console log. If `false`, an issue will be created to list all RSS feed entries found.
 - `labels` - A multi-line list of labels to search for. E.g. including `actions` will trigger the following search; `https://github.blog/feed/?s=actions`
+- `days` - Number of days worth of posts to be included in the list
 
 ## Outputs
 
@@ -41,17 +42,16 @@ jobs:
           labels: |
             'actions'
             'copilot'
+          days: 7
 ```
 
 ## ToDo
 
-- [ ] Sort blog entries by date (descending)
-- [ ] Include for each entry in list:
-  - Date of posting
-- [ ] Allow input parameter for how many days worth of posts should be included in list
 - [ ] Reformat / polish to include blog post date span in issue title 
 - [ ] Check and fix for vulnerable coding patterns
 - [ ] Use GITHUB_TOKEN for API authentication if possible
 - [ ] Add tests
 - [ ] Add CI workflow with test suite
 - [ ] Update README with updated info
+
+## Last modified on: 2023-09-25

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   labels:
     description: Multi-line list of labels to filter on
     required: true
+  days:
+    description: Number of days worth of posts to be included in the list
+    required: false
+    default: '7'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ async function run() {
     const token = core.getInput('token');
     const dryRun = core.getBooleanInput('dry-run');
     const labels = core.getMultilineInput('labels');
+    const days = core.getInput('days');
 
     const baseUrl = 'https://github.blog/feed/?s=';
     const octokit = github.getOctokit(token);
@@ -23,19 +24,21 @@ async function run() {
       await _formatAndPrintLogOutput(feed);
     }
 
-    // TODO: Create an issue in the workflow repo listing all rss feed items with their hyperlink, publication date, and title. Label the issue as "news-update".
+    const filteredFeeds = _filterFeedsByDays(allFeeds, days);
+    const sortedFeeds = _sortFeedsByDate(filteredFeeds);
+
     if (!dryRun) {
-      const issueBody = allFeeds.map(item => `- [${item.title}](${item.link})`).join('\n');
+      const issueBody = sortedFeeds.map(item => `- [${item.title}](${item.link}) - ${item.pubDate}`).join('\n');
       const issue = await octokit.rest.issues.create({
-      owner: github.context.repo.owner,
-      repo: github.context.repo.repo,
-      title: 'News Update',
-      body: issueBody,
-      labels: ['news-update']
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        title: 'News Update',
+        body: issueBody,
+        labels: ['news-update']
       });
     }
 
-    core.setOutput('feeds', JSON.stringify(allFeeds));
+    core.setOutput('feeds', JSON.stringify(sortedFeeds));
 
   } catch (error) {
     core.setFailed(error.message);
@@ -49,6 +52,17 @@ async function _getRssFeed(url, label) {
   const feed = await parser.parseURL(rssFeedUrl);
 
   return feed;
+}
+
+function _filterFeedsByDays(feeds, days) {
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - days);
+
+  return feeds.filter(feed => new Date(feed.pubDate) >= cutoffDate);
+}
+
+function _sortFeedsByDate(feeds) {
+  return feeds.sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate));
 }
 
 /**

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,32 @@
+const { _getRssFeed, _formatAndPrintLogOutput, _filterFeedsByDays, _sortFeedsByDate } = require('../index');
+const sinon = require('sinon');
+const { expect } = require('chai');
+
+describe('RSS Feed Tests', () => {
+  describe('_filterFeedsByDays', () => {
+    it('should filter feeds based on the input parameter for days', () => {
+      const feeds = [
+        { pubDate: new Date().toISOString() },
+        { pubDate: new Date(Date.now() - 86400000).toISOString() }, // 1 day ago
+        { pubDate: new Date(Date.now() - 172800000).toISOString() }, // 2 days ago
+        { pubDate: new Date(Date.now() - 259200000).toISOString() }, // 3 days ago
+      ];
+      const days = 2;
+      const filteredFeeds = _filterFeedsByDays(feeds, days);
+      expect(filteredFeeds.length).to.equal(2);
+    });
+  });
+
+  describe('_sortFeedsByDate', () => {
+    it('should sort feeds by date in descending order', () => {
+      const feeds = [
+        { pubDate: new Date(Date.now() - 86400000).toISOString() }, // 1 day ago
+        { pubDate: new Date().toISOString() },
+        { pubDate: new Date(Date.now() - 172800000).toISOString() }, // 2 days ago
+      ];
+      const sortedFeeds = _sortFeedsByDate(feeds);
+      expect(new Date(sortedFeeds[0].pubDate)).to.be.above(new Date(sortedFeeds[1].pubDate));
+      expect(new Date(sortedFeeds[1].pubDate)).to.be.above(new Date(sortedFeeds[2].pubDate));
+    });
+  });
+});


### PR DESCRIPTION
Add sorting and filtering of blog entries by date, and include date in issue body.

* **index.js**
  - Add input parameter for days.
  - Filter and sort `allFeeds` array by `pubDate` in descending order.
  - Include `pubDate` in the issue body for each entry.
  - Add helper functions `_filterFeedsByDays` and `_sortFeedsByDate`.

* **README.md**
  - Update usage example to include new input parameter for days.
  - Remove to-do items related to sorting blog entries by date and including the date of posting for each entry.
  - Add date of modification at the end of the file.

* **.github/workflows/get-blog-feed.yml**
  - Add input parameter for days in the workflow example.

* **action.yml**
  - Add input parameter for days.

* **tests/index.test.js**
  - Add tests for sorting blog entries by date.
  - Add tests for filtering blog entries based on the input parameter for days.

* **.github/workflows/ci.yml**
  - Add CI workflow with test suite.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ankitdhannarbi/action-gh-blog-feed-forked/pull/1?shareId=01b58d50-4228-4258-9518-1f384340cab6).